### PR TITLE
20230524 Juan Inventario Corrección bug acentos

### DIFF
--- a/resources/views/inventario/inventario-show.blade.php
+++ b/resources/views/inventario/inventario-show.blade.php
@@ -206,8 +206,8 @@
                                                 <h6><u>Sistema Operativo:</u>
                                                     {{ $puesto->equipamiento->cpu->sistema_operativo }}</h6>
                                                 
-                                                @if ($puesto->equipamiento->cpu->descripción)
-                                                    <h6><u>Descripción:</u> {{ $puesto->equipamiento->cpu->descripción }}</h6>    
+                                                @if ($puesto->equipamiento->cpu->descripcion)
+                                                    <h6><u>Descripción:</u> {{ $puesto->equipamiento->cpu->descripcion }}</h6>    
                                                 @else
                                                     <h6><u>Descripción:</u> -</h6>
                                                 @endif

--- a/resources/views/inventario/puestos/show.blade.php
+++ b/resources/views/inventario/puestos/show.blade.php
@@ -229,8 +229,8 @@
                                                 <h6><u>RAM cantidad:</u> {{ $puesto->equipamiento->cpu->ram_cant_gb }}</h6>
                                                 <h6><u>Sistema Operativo:</u>
                                                     {{ $puesto->equipamiento->cpu->sistema_operativo }}</h6>
-                                                @if ($puesto->equipamiento->cpu->descripción)
-                                                    <h6><u>Descripción:</u> {{ $puesto->equipamiento->cpu->descripción }}</h6>    
+                                                @if ($puesto->equipamiento->cpu->descripcion)
+                                                    <h6><u>Descripción:</u> {{ $puesto->equipamiento->cpu->descripcion }}</h6>    
                                                 @else
                                                     <h6><u>Descripción:</u> - </h6>
                                                 @endif


### PR DESCRIPTION
tenia un acento en "descripción", y el atributo no lo tenía, por eso tanto en la vista del inventario como en la del puesto, no mostraba la descripción del CPU. Corregido